### PR TITLE
Use os.Hostname() instead of HOSTNAME env variable

### DIFF
--- a/dependencies/config/config.go
+++ b/dependencies/config/config.go
@@ -40,8 +40,8 @@ func NewConfig(name string) Config {
 		logger.Error.Print("Environment variable INTERFACE_NAME not set")
 		os.Exit(1)
 	}
-	hostname := os.Getenv("HOSTNAME")
-	if hostname == "" {
+	hostname, err := os.Hostname()
+	if err != nil {
 		logger.Error.Print("Environment variable HOSTNAME not set")
 	}
 	config.params.HOSTNAME = hostname


### PR DESCRIPTION
The assumption was made that the HOSTNAME environment variable
was available. While it is the case in Docker containers, it is
not in rkt containers. By using os.Hostname(), we have the
guarantee that we'll retrieve the hostname with both runtimes.