### PR TITLE
Add requireSameNode field for pod dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,16 @@ Example:
 `DEPENDENCY_SOCKET=/var/run/openvswitch/ovs.socket`
 
 ### Pod
-Checks if at least one pod matching the specified labels is already running on the same host.
+Checks if at least one pod matching the specified labels is already running, by
+default anywhere in the cluster, or use `"requireSameNode": true` to require a
+a pod on the same node.
 In contrast to other dependencies, the syntax uses json in order to avoid inventing a new
 format to specify labels and the parsing complexities that would come with that.
 This dependency requires a `POD_NAME` env which can be easily passed through the
 [downward api](http://kubernetes.io/docs/user-guide/downward-api/). The `POD_NAME` variable is mandatory and is used to resolve dependencies.
 Example:
 
-`DEPENDENCY_POD="[{\"namespace\": \"foo\", \"labels\": {\"k1\": \"v1\", \"k2\": \"v2\"}}, {\"labels\": {\"k1\": \"v1\", \"k2\": \"v2\"}}]"`
+`DEPENDENCY_POD="[{\"namespace\": \"foo\", \"labels\": {\"k1\": \"v1\", \"k2\": \"v2\"}}, {\"labels\": {\"k1\": \"v1\", \"k2\": \"v2\"}, \"requireSameNode\": true}]"`
 
 ## Image
 

--- a/util/env/env.go
+++ b/util/env/env.go
@@ -18,8 +18,9 @@ type Dependency struct {
 }
 
 type PodDependency struct {
-	Labels    map[string]string
-	Namespace string
+	Labels          map[string]string
+	Namespace       string
+	RequireSameNode bool
 }
 
 func SplitCommand() []string {
@@ -88,8 +89,8 @@ func SplitPodEnvToDeps(env string) []PodDependency {
 	for i, dep := range deps {
 		if dep.Namespace == "" {
 			dep.Namespace = namespace
-			deps[i] = dep
 		}
+		deps[i] = dep
 	}
 
 	return deps

--- a/util/env/env_test.go
+++ b/util/env/env_test.go
@@ -96,17 +96,17 @@ func TestSplitPodEnvToDepsSuccess(t *testing.T) {
 	defer os.Unsetenv("NAMESPACE")
 	os.Setenv("NAMESPACE", `TEST_NAMESPACE`)
 	defer os.Unsetenv("TEST_LIST")
-	os.Setenv("TEST_LIST", `[{"namespace": "foo", "labels": {"k1": "v1", "k2": "v2"}}, {"labels": {"k1": "v1", "k2": "v2"}}]`)
+	os.Setenv("TEST_LIST", `[{"namespace": "foo", "labels": {"k1": "v1", "k2": "v2"}, "requireSameNode": true}, {"labels": {"k1": "v1", "k2": "v2"}}]`)
 	actual := SplitPodEnvToDeps("TEST_LIST")
 	expected := []PodDependency{
 		PodDependency{Namespace: "foo", Labels: map[string]string{
 			"k1": "v1",
 			"k2": "v2",
-		}},
+		}, RequireSameNode: true},
 		PodDependency{Namespace: "TEST_NAMESPACE", Labels: map[string]string{
 			"k1": "v1",
 			"k2": "v2",
-		}},
+		}, RequireSameNode: false},
 	}
 
 	if !reflect.DeepEqual(expected, actual) {


### PR DESCRIPTION
Previously pod dependencies always required the pod to be on the same
node.  Though this was documented it often did not match user intuition
as merely depending on a pod shouldn't require anything more than it
existing somewhere in the cluster.  This adds a field to pod
dependencies to specify whether the pod is required to be on the same
node.  This defaults to false for the reasons above, which is a breaking
change.